### PR TITLE
docs: surface the two Remix entry points as cards on the landing page

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -995,6 +995,61 @@ span.fa.fa-book {
   display: none !important;
 }
 
+/* Map sphinx-design's palette onto the Remix theme tokens, so its cards and
+   buttons follow light/dark/black mode like the rest of the docs. */
+:root {
+  --sd-color-primary: var(--color-primary);
+  --sd-color-primary-highlight: var(--color-hover);
+  --sd-color-primary-text: #ffffff;
+  --sd-color-card-background: var(--color-background);
+  --sd-color-card-border: var(--color-primary-transparent);
+  --sd-color-card-footer: var(--color-code-background);
+  --sd-color-card-text: var(--color-body);
+  --sd-color-shadow: var(--color-primary-transparent);
+}
+
+/* The RTD theme sets a global `p { margin: 0 0 24px }`, which leaves a large
+   dead gap under the single line of body copy in a compact card. */
+.sd-card .sd-card-text {
+  margin-bottom: 0;
+}
+
+/* Start-here cards on the landing page.
+   The card is contained by its surface fill rather than by a hairline border,
+   so the button inside it stays the strongest element in the box. */
+.remix-start-card {
+  background-color: var(--color-code-background);
+  border: none !important;
+  border-radius: 0.75rem;
+  box-shadow: none !important;
+}
+
+.remix-start-card .sd-card-body {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1.25rem;
+}
+
+.remix-start-card .sd-card-title {
+  font-size: var(--size-body-big);
+  margin-bottom: 0;
+}
+
+.remix-start-card .sd-card-text {
+  color: var(--color-body-light);
+}
+
+/* Push the button to the bottom so both cards align regardless of copy length */
+.remix-start-card .sd-card-body > p {
+  margin-bottom: 0;
+}
+
+.remix-start-card .sd-card-body > p:last-child {
+  margin-top: auto;
+}
+
 /* 1) Keep images small and inside the card */
 .plugin-card .sd-card-img-top {
   max-height: 96px; /* try 80–120px to taste */

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -34,7 +34,7 @@ With Remix Desktop, you can:
 
 ## Installing Remix Desktop
 
-Remix Desktop is available for macOS, Linux, and Windows. To install it for your operating system, visit the [Remix Desktop releases page](https://github.com/remix-project-org/remix-desktop/releases) and choose the installer for your operating system.
+Remix Desktop is available for macOS, Linux, and Windows. To install it for your operating system, visit the [Remix Desktop download page](https://remix.live/desktop) and choose the installer for your operating system.
 
 ![Remix Desktop releases page](images/desktop/releases.png)
 

--- a/docs/file_explorer.md
+++ b/docs/file_explorer.md
@@ -53,7 +53,7 @@ You will see a list of all the workspaces in your browser storage, choose the on
 
 ### Remix Desktop
 
-Remix Desktop is a version of the Remix IDE that exists as a native app on your computer instead of a browser app. Since it's a native app on your computer, the files are saved directly to your hard drive. You can download Remix Desktop on [the releases page](https://github.com/remix-project-org/remix-desktop/releases).
+Remix Desktop is a version of the Remix IDE that exists as a native app on your computer instead of a browser app. Since it's a native app on your computer, the files are saved directly to your hard drive. You can download Remix Desktop on [the download page](https://remix.live/desktop).
 
 ```{tip}
 For more information, see the {doc}`Remix Desktop <desktop/>` documentation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,9 +9,31 @@ Welcome to Remix's documentation!
 It requires no setup, fosters a fast development cycle, and has a rich set of plugins with intuitive GUIs.  
 The IDE comes in two flavors (web app or desktop app).
 
-**Remix Desktop**, see: `Download page <https://github.com/remix-project-org/remix-desktop/releases>`__
+.. grid:: 2
+   :gutter: 3
 
-**Remix Online IDE**, see: `https://remix.ethereum.org <https://remix.ethereum.org>`__
+   .. grid-item-card:: Remix Online IDE
+      :columns: 12 12 6 6
+      :class-card: remix-start-card
+
+      Run Remix in your browser. No setup required.
+
+      .. button-link:: https://remix.ethereum.org
+         :color: primary
+
+         Launch Remix
+
+   .. grid-item-card:: Remix Desktop
+      :columns: 12 12 6 6
+      :class-card: remix-start-card
+
+      Download the desktop app for macOS, Windows or Linux.
+
+      .. button-link:: https://remix.live/desktop
+         :color: primary
+         :outline:
+
+         Download
 
 **Supported browsers:** **Firefox**, **Chrome**, **Brave**. 
 
@@ -30,7 +52,7 @@ Additional information can be found on our `Substack blog <https://ethereumremix
 Useful Links
 ------------
 
-- `Remix Desktop <https://github.com/remix-project-org/remix-desktop/releases>`__ - Remix Desktop's release page. 
+- `Remix Desktop <https://remix.live/desktop>`__ - Remix Desktop's download page. 
 
 - `Remix on Github <https://github.com/remix-project-org/remix-project>`__
 

--- a/docs/locations.md
+++ b/docs/locations.md
@@ -15,7 +15,7 @@ myst:
 
 - GitHub repository: [https://github.com/remix-project-org](https://github.com/remix-project-org). The README contains instructions for running Remix-IDE locally.
 
-- Remix Desktop is an Electron App. Here is the [release page](https://github.com/remix-project-org/remix-desktop/releases).
+- Remix Desktop is an Electron App. Here is the [download page](https://remix.live/desktop).
 
 - The Remix X account is [EthereumRemix](https://x.com/EthereumRemix).
 


### PR DESCRIPTION
Restyles the two main Remix entry point links on the docs landing page as cards so they stand out.